### PR TITLE
Fix CB0 alignment with addresses used for 8/16-bit LDG/STG

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3868;
+        private const uint CodeGenVersion = 3897;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
@@ -128,6 +128,11 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                 GetStorageOffset(block, Utils.FindLastOperation(addrLow, block), baseAddressCbOffset) :
                 (null, 0);
 
+            if (byteOffset != null)
+            {
+                ReplaceAddressAlignment(node.List, addrLow, byteOffset, constantOffset);
+            }
+
             if (byteOffset == null)
             {
                 Operand baseAddrLow = Cbuf(0, baseAddressCbOffset);
@@ -154,11 +159,6 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                 node.List.AddBefore(node, addOp);
 
                 byteOffset = offset;
-            }
-
-            if (byteOffset != null)
-            {
-                ReplaceAddressAlignment(node.List, addrLow, byteOffset, constantOffset);
             }
 
             if (isStg16Or8)


### PR DESCRIPTION
This replacement is meant to be done with the original identified byteOffset, not the one assigned later on by the below conditionals (that already has the constant offset added, for instance).

This fixes videos being pixelated in Xenoblade 3, and other regressions that might have happened since #3847.