### PR TITLE
GPU: Periodically clear volatile flags

### DIFF
--- a/Ryujinx.Cpu/Tracking/CpuMultiRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuMultiRegionHandle.cs
@@ -15,6 +15,7 @@ namespace Ryujinx.Cpu.Tracking
             _impl = impl;
         }
 
+        public void ClearVolatile(ulong mask) => _impl.ClearVolatile(mask);
         public void Dispose() => _impl.Dispose();
         public void ForceDirty(ulong address, ulong size) => _impl.ForceDirty(address, size);
         public IEnumerable<IRegionHandle> GetHandles() => _impl.GetHandles();

--- a/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
@@ -18,6 +18,7 @@ namespace Ryujinx.Cpu.Tracking
             _impl = impl;
         }
 
+        public void ClearVolatile() => _impl.ClearVolatile();
         public void Dispose() => _impl.Dispose();
         public bool DirtyOrVolatile() => _impl.DirtyOrVolatile();
         public void ForceDirty() => _impl.ForceDirty();

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -70,6 +70,11 @@ namespace Ryujinx.Graphics.Gpu
         internal List<Action> SyncpointActions { get; }
 
         /// <summary>
+        /// Total number of presented frames. Used by some cleanup operations.
+        /// </summary>
+        internal ulong FrameNumber { get; private set; }
+
+        /// <summary>
         /// Queue with deferred actions that must run on the render thread.
         /// </summary>
         internal Queue<Action> DeferredActions { get; }
@@ -262,6 +267,14 @@ namespace Ryujinx.Graphics.Gpu
             {
                 physicalMemory.ShaderCache.ProcessShaderCacheQueue();
             }
+        }
+
+        /// <summary>
+        /// Advances internal frame number.
+        /// </summary>
+        internal void AdvanceFrame()
+        {
+            FrameNumber++;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Window.cs
+++ b/Ryujinx.Graphics.Gpu/Window.cs
@@ -197,6 +197,7 @@ namespace Ryujinx.Graphics.Gpu
         public void Present(Action swapBuffersCallback)
         {
             _context.AdvanceSequence();
+            _context.AdvanceFrame();
 
             if (_frameQueue.TryDequeue(out PresentationTexture pt))
             {

--- a/Ryujinx.Memory/Tracking/MultiRegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/MultiRegionHandle.cs
@@ -397,6 +397,21 @@ namespace Ryujinx.Memory.Tracking
             }
         }
 
+        public void ClearVolatile(ulong mask)
+        {
+            while (mask != 0)
+            {
+                int bit = BitOperations.TrailingZeroCount(mask);
+
+                for (int i = bit; i < _handles.Length; i += 64)
+                {
+                    _handles[i].ClearVolatile();
+                }
+
+                mask &= ~(1UL << bit);
+            }
+        }
+
         public void Dispose()
         {
             foreach (var handle in _handles)

--- a/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -163,7 +163,7 @@ namespace Ryujinx.Memory.Tracking
         /// <summary>
         /// Clear the volatile state of this handle.
         /// </summary>
-        private void ClearVolatile()
+        public void ClearVolatile()
         {
             _volatileCount = 0;
             _volatile = false;


### PR DESCRIPTION
Buffer tracking handles have an optimisation where they can be set as _volatile, which means that we assume the data is always modified. This avoids the cost of setting and clearing memory protection on this frequently modified data, as generally the game will have changed it every frame anyways.

This works fine in games that always put their commonly modified constant buffers in the same place (say, for model world matrices might be updated every use), but if the memory is freed and reused by buffer data that is modified less often, the _volatile flag could remain and force data to upload every frame that hasn't changed.

The way these flags are set is determining when multiple consecutive sequence number checks say that the buffer is dirty. If they do, then the tracking handle's _volatile flag is set and it is always assumed to be dirty.

Unfortunately, this means we lose that original source of information - we aren't tracking memory writes to the buffer, so we don't know when it _stops_ updating every frame. The only solution is to unset some of these periodically, and have them correct their state in the frame or two afterwards.

The strategy for doing this is by keeping track of the number of elapsed frames, so that we can reset volatile flags periodically. We only check this when buffer data is _uploaded_, as that is an indicator the tracking handle might be _volatile.

After a set number of frames has passed since the last check, on upload we manually set. This is done with a period of 30 frames right now - each 30 frames clears 1/64 buffer volatile flags. The flag a period clears is based on its frame number, and the buffer's page number. If a buffer isn't synchronized in a long time, it will clear all the flags for the clearing periods that it missed (for example, after 1920 frames a check will clear all flags in the buffer).

All this is attempting to minimize iteration of buffers, unnecessary checks, expensively resetting all flags at the same time... but it can still be less than ideal clearing these flags. Notably there's no feedback whether any part of a multiregionhandle is set as volatile, so we end up iterating handles even if they were never volatile. The infrequency and splitting the work into only the buffers that are uploaded, and only 1/64 of the flags every 30 frames hopefully mitigate all of this.

Fixes performance lowering dramatically over time in Pokemon Scarlet/Violet. May fix similar issues in other games, even if they are more subtle.