### PR TITLE
Fix the issue of unequal check for amiibo file date due to the lack o…

### DIFF
--- a/src/Ryujinx/Ui/Windows/AmiiboWindow.cs
+++ b/src/Ryujinx/Ui/Windows/AmiiboWindow.cs
@@ -180,7 +180,7 @@ namespace Ryujinx.Ui.Windows
 
                 if (response.IsSuccessStatusCode)
                 {
-                    return response.Content.Headers.LastModified != oldLastModified;
+                    return response.Content.Headers.LastModified != new DateTimeOffset(oldLastModified.Ticks - (oldLastModified.Ticks % TimeSpan.TicksPerSecond), TimeSpan.Zero);
                 }
 
                 return false;


### PR DESCRIPTION
…f sub-second units in the header, causing slow opening of the amiibo interface.